### PR TITLE
runtests.bat: create bin folder if missing #11

### DIFF
--- a/test/runtests.bat
+++ b/test/runtests.bat
@@ -1,4 +1,8 @@
 @ECHO OFF
+
+REM create bin directory if it doesn't exist
+if not exist ..\bin mkdir ..\bin
+
 REM compile the code into the bin folder
 javac  ..\src\seedu\addressbook\Addressbook.java -d ..\bin
 


### PR DESCRIPTION
Fixes #11 

Add line to check and create bin directory on windows.
