### PR TITLE
Ensure Java 9 compatibility #99

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -7,7 +7,7 @@
 
 *Prerequisites*
 
-* JDK 8 or later
+* JDK 9 or later
 * IntelliJ IDE
 
 *Importing the project into IntelliJ*
@@ -15,7 +15,7 @@
 . Open IntelliJ (if you are not in the welcome screen, click `File` > `Close Project` to close the existing project dialog first)
 . Set up the correct JDK version
 .. Click `Configure` > `Project Defaults` > `Project Structure`
-.. If JDK 8 is listed in the drop down, select it. If it is not, click `New...` and select the directory where you installed JDK 8.
+.. If JDK 9 is listed in the drop down, select it. If it is not, click `New...` and select the directory where you installed JDK 9.
 .. Click `OK`.
 . Click `Import Project`
 . Locate the project directory and click `OK`


### PR DESCRIPTION
Fixes #99

```
The project currently runs on Java 8.

Since AddressBookL4 is already running on Java 9,
this project should be upgraded to run on Java 9 as well
for consistency.

Since the project is already compatible with Java 9,
let's update the DeveloperGuide to mention using
Java 9 or later.
```