### PR TITLE
Fix runtests scripts proceeding on compilation error #92

### DIFF
--- a/test/runtests.bat
+++ b/test/runtests.bat
@@ -5,6 +5,9 @@ if not exist ..\bin mkdir ..\bin
 
 REM compile the code into the bin folder
 javac  ..\src\seedu\addressbook\Addressbook.java -d ..\bin
+IF ERRORLEVEL 1 GOTO errorHandling
+REM no error here, errorlevel == 0
+
 
 REM (invalid) no parent directory, invalid filename with no extension
 java -classpath ..\bin seedu.addressbook.AddressBook " " < NUL > actual.txt
@@ -23,3 +26,9 @@ java -classpath ..\bin seedu.addressbook.AddressBook < input.txt >> actual.txt
 
 REM compare the output to the expected output
 FC actual.txt expected.txt
+exit /b 1
+
+:errorHandling (
+echo ********** BUILD FAILURE ********** 
+exit /b 1
+)

--- a/test/runtests.bat
+++ b/test/runtests.bat
@@ -5,9 +5,11 @@ if not exist ..\bin mkdir ..\bin
 
 REM compile the code into the bin folder
 javac  ..\src\seedu\addressbook\Addressbook.java -d ..\bin
-IF ERRORLEVEL 1 GOTO errorHandling
+IF ERRORLEVEL 1 (
+    echo ********** BUILD FAILURE ********** 
+    exit /b 1
+)
 REM no error here, errorlevel == 0
-
 
 REM (invalid) no parent directory, invalid filename with no extension
 java -classpath ..\bin seedu.addressbook.AddressBook " " < NUL > actual.txt
@@ -26,9 +28,3 @@ java -classpath ..\bin seedu.addressbook.AddressBook < input.txt >> actual.txt
 
 REM compare the output to the expected output
 FC actual.txt expected.txt
-exit /b 1
-
-:errorHandling (
-echo ********** BUILD FAILURE ********** 
-exit /b 1
-)

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -9,8 +9,12 @@ then
     mkdir ../bin
 fi
 
-# compile the code into the bin folder
-javac  ../src/seedu/addressbook/AddressBook.java -d ../bin
+# compile the code into the bin folder, terminates if error occurred
+if ! javac  ../src/seedu/addressbook/AddressBook.java -d ../bin
+then
+    echo "********** BUILD FAILURE **********"
+    exit 1
+fi
 
 # (invalid) no parent directory, invalid filename with no extension
 java -classpath ../bin seedu.addressbook.AddressBook ' ' < /dev/null > actual.txt


### PR DESCRIPTION
Fix #92 

```
Runtests scripts compile the program under test, before executing the
tests. The tests always execute regardless of whether the compilation
succeeds or not.

If the program has compilation errors, the runtests scripts are actually
testing an older version of the program without the errors. This results
in misleading test results.

Let's teach the scripts to terminate immediately when the program fails
to compile.
```